### PR TITLE
Use openstack-release package to determine codename

### DIFF
--- a/charms_openstack/charm/core.py
+++ b/charms_openstack/charm/core.py
@@ -616,6 +616,14 @@ class BaseOpenStackCharm(object, metaclass=BaseOpenStackCharmMeta):
                                 apt_cache_sufficient=False):
         """Derive OpenStack release codename from a package.
 
+
+        Initially, see if the openstack-release pkg is available (by trying
+        to install it) and use it instead.
+
+        If it isn't then it falls back to the existing method of checking the
+        version of the package passed and then resolving the version from that
+        using lookup tables.
+
         :param package: Package name to lookup (ie. in apt cache)
         :type package: str
         :param codenames: Map of package to (version, os_release) tuples.
@@ -644,6 +652,11 @@ class BaseOpenStackCharm(object, metaclass=BaseOpenStackCharmMeta):
         :rtype: Optional[str]
         :raises: AttributeError, ValueError
         """
+
+        codename = os_utils.get_installed_os_version()
+        if codename:
+            return codename
+
         try:
             vers = BaseOpenStackCharm.get_package_version(
                 package,

--- a/unit_tests/charms_openstack/charm/test_core.py
+++ b/unit_tests/charms_openstack/charm/test_core.py
@@ -899,6 +899,9 @@ class TestMyOpenStackCharm(BaseOpenStackCharmTest):
                           'upstream_version')
         self.patch_object(chm_core.os_utils, 'snap_install_requested',
                           return_value=False)
+        self.patch_object(chm_core.os_utils, 'get_installed_os_version')
+        self.get_installed_os_version.return_value = None
+        self.upstream_version.return_value = '3.0.0~b1'
         self.upstream_version.return_value = '3.0.0~b1'
         self.assertEqual(
             chm_core.BaseOpenStackCharm.get_os_codename_package(
@@ -913,7 +916,14 @@ class TestMyOpenStackCharm(BaseOpenStackCharmTest):
             'newton')
         self.upstream_version.assert_called_once_with(
             pkg_mock.version)
+        # Test Wallaby
+        self.get_installed_os_version.return_value = 'wallaby'
+        self.assertEqual(
+            chm_core.BaseOpenStackCharm.get_os_codename_package(
+                'testpkg', codenames),
+            'wallaby')
         # Test non-fatal fail
+        self.get_installed_os_version.return_value = None
         self.assertEqual(
             chm_core.BaseOpenStackCharm.get_os_codename_package(
                 'unknownpkg', codenames, fatal=False),


### PR DESCRIPTION
The use of package versions to look up OpenStack codenames is
deprecated for in favor of using the openstack-release package.
The openstack-release package is available for Wallaby onward.